### PR TITLE
Update commander.ts

### DIFF
--- a/apps/web/data/classes/commander.ts
+++ b/apps/web/data/classes/commander.ts
@@ -199,7 +199,7 @@ const commanderFeatures: ClassFeature[] = [
     description: "Gain the Coordinated Strike! Commander's Order.",
     traits: [
       {
-        id: "coordinated-strike-pool",
+        id: "coordinated-strikes-pool",
         type: "resource",
         resourceDefinition: {
           id: "coordinated-strikes",
@@ -230,7 +230,7 @@ const commanderFeatures: ClassFeature[] = [
           description: "You and an ally within 6 spaces both immediately make a weapon attack or cast a cantrip for free.",
           resourceCost: {
             type: "fixed",
-            resourceId: "coordinated-strike-pool-0",
+            resourceId: "coordinated-strikes",
             amount: 1
           },
           frequency: "per_turn",

--- a/apps/web/data/classes/commander.ts
+++ b/apps/web/data/classes/commander.ts
@@ -202,7 +202,7 @@ const commanderFeatures: ClassFeature[] = [
         id: "coordinated-strike-pool",
         type: "resource",
         resourceDefinition: {
-          id: "coordinated-strike-pool-0",
+          id: "coordinated-strikes",
           name: "Coordinated Strikes",
           description:
             "Grants free attacks in combat",
@@ -216,7 +216,7 @@ const commanderFeatures: ClassFeature[] = [
           },
           maxValue: {
             type: "formula",
-            expression: "1*INT",
+            expression: "INT",
           },
         },
       },
@@ -225,7 +225,7 @@ const commanderFeatures: ClassFeature[] = [
         name: "Coordinated Strike!",
         type: "ability",
         ability: {
-          id: "coordinated-strike-base-0",
+          id: "coordinated-strike",
           name: "coordinated Strike!",
           description: "You and an ally within 6 spaces both immediately make a weapon attack or cast a cantrip for free.",
           resourceCost: {

--- a/apps/web/data/classes/commander.ts
+++ b/apps/web/data/classes/commander.ts
@@ -4,28 +4,6 @@ import { ClassFeature } from "@/lib/schemas/features";
 // Commander's Orders - Feature Pool
 const commandersOrdersFeatures: ClassFeature[] = [
   {
-    id: "coordinated-strike-order",
-    level: 1,
-    name: "Coordinated Strike!",
-    description:
-      "(1/round) Free action: you and an ally within 6 spaces both immediately make a weapon attack or cast a cantrip for free. You can do this INT times/Safe Rest.",
-    traits: [
-      {
-        id: "coordinated-strike-order-0",
-        type: "ability",
-        ability: {
-          id: "coordinated-strike",
-          name: "Coordinated Strike!",
-          description:
-            "You and an ally within 6 spaces both immediately make a weapon attack or cast a cantrip for free.",
-          type: "action",
-          frequency: "per_turn",
-          maxUses: { type: "fixed", value: 1 },
-        },
-      },
-    ],
-  },
-  {
     id: "face-me-order",
     level: 1,
     name: "Face Me!",
@@ -221,15 +199,41 @@ const commanderFeatures: ClassFeature[] = [
     description: "Gain the Coordinated Strike! Commander's Order.",
     traits: [
       {
-        id: "commander-coordinated-strike-0",
+        id: "coordinated-strike-pool",
+        type: "resource",
+        resourceDefinition: {
+          id: "coordinated-strike-pool-0",
+          name: "Coordinated Strikes",
+          description:
+            "Grants free attacks in combat",
+          colorScheme: "focused-mind",
+          icon: "target",
+          resetCondition: "safe_rest",
+          resetType: "to_max",
+          minValue: {
+            type: "fixed",
+            value: "0",
+          },
+          maxValue: {
+            type: "formula",
+            expression: "1*INT",
+          },
+        },
+      },
+      { 
+        id: "coordinated-strike-base",
+        name: "Coordinated Strike!",
         type: "ability",
         ability: {
-          id: "coordinated-strike-base",
-          name: "Coordinated Strike!",
-          description:
-            "You and an ally within 6 spaces both immediately make a weapon attack or cast a cantrip for free.",
-          type: "action",
-          frequency: "per_safe_rest",
+          id: "coordinated-strike-base-0",
+          name: "coordinated Strike!",
+          description: "You and an ally within 6 spaces both immediately make a weapon attack or cast a cantrip for free.",
+          resourceCost: {
+            type: "fixed",
+            resourceId: "coordinated-strike-pool-0",
+            amount: 1
+          },
+          frequency: "per_turn",
           maxUses: { type: "fixed", value: 1 },
         },
       },


### PR DESCRIPTION
Removed:
- id:coordinated-strike-order

Added:
- id:coordinated-strike-pool

Changed:
-id coordinated-strike-base  now consumes id coordinated-strike-pool resource and has a "per_turn" frequency.

Message:
The Commander level 1 feature reads:
"Coordinated Strike! Gain the Coordinated Strike! Commander's Order." 

And the "Coordinated Strike" Order reads:
Coordinated Strike! (1/round) Free action:
you and an ally within 6 spaces both immediately make a weapon attack or cast a cantrip for free. You can do this INT times/Safe Rest.

So, I removed coordinated strikes from the commanders orders pool because you get the ability automatically and as far as I understand you cant pick the same order twice. I made the coordinate strike resource because the coordinated strike ability is both a per turn action and has a limited ammount of uses per rest based on the characters INT. I belive this is the best way to reflect that.