### PR TITLE
Update commander.ts

### DIFF
--- a/apps/web/data/classes/commander.ts
+++ b/apps/web/data/classes/commander.ts
@@ -206,7 +206,7 @@ const commanderFeatures: ClassFeature[] = [
           resetType: "to_max",
           minValue: {
             type: "fixed",
-            value: 0,
+            value: 1,
           },
           maxValue: {
             type: "formula",


### PR DESCRIPTION
Updated:
-Coordinated strikes resource pool now has minimum of 1 rather than 0.

Message:
As soon as I looked at one of the characters in my campaign I imidietely realised they could not use the coordinated strikes ability caused they have a negative INT score.